### PR TITLE
Enable supabase login and fix event creation

### DIFF
--- a/src/components/Events/EventManagement.tsx
+++ b/src/components/Events/EventManagement.tsx
@@ -256,19 +256,23 @@ export const EventManagement: React.FC = () => {
                   className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 />
               </div>
-            </form>
 
-            <div className="p-6 border-t border-gray-200 flex justify-end space-x-3">
-              <button
-                onClick={() => setShowCreateForm(false)}
-                className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
-              >
-                Cancel
-              </button>
-              <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
-                Create Event
-              </button>
-            </div>
+              <div className="p-6 border-t border-gray-200 flex justify-end space-x-3">
+                <button
+                  type="button"
+                  onClick={() => setShowCreateForm(false)}
+                  className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                >
+                  Create Event
+                </button>
+              </div>
+            </form>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- connect to Supabase only when credentials exist
- show an error when credentials are missing
- keep demo logins but allow real Supabase logins
- fix the create event form so the submit button works

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688849b9d61483259307e2520b0a5be4