### PR TITLE
Handle missing profile on login

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -136,6 +136,24 @@ export const getUserProfile = async (userId: string) => {
   return { data, error };
 };
 
+export const createUserProfile = async (
+  profile: Database['public']['Tables']['user_profiles']['Insert']
+) => {
+  devLog('[supabase] createUserProfile', profile);
+  const { data, error } = await supabase
+    .from('user_profiles')
+    .insert(profile)
+    .single();
+
+  if (error) {
+    devError('[supabase] createUserProfile error:', error);
+  } else {
+    devLog('[supabase] createUserProfile id:', data?.id);
+  }
+
+  return { data, error };
+};
+
 export const getGymnastProfile = async (userId: string) => {
   devLog('[supabase] getGymnastProfile for', userId);
   const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- create `createUserProfile` helper for inserting a profile
- call `loadUserProfile` with the user email
- if no profile exists, automatically insert a blank profile so login proceeds

## Testing
- `npm run lint` *(fails: demoUsers unused)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6889973f0df48325acc20db6ed5ef227