### PR TITLE
Integrate gyms and gymnasts with Supabase

### DIFF
--- a/src/components/Gyms/GymManagement.tsx
+++ b/src/components/Gyms/GymManagement.tsx
@@ -1,88 +1,13 @@
 import React, { useState } from 'react';
 import { Building2, MapPin, Phone, Mail, Globe, CheckCircle, Clock, Plus, Edit, Trash2, Users } from 'lucide-react';
-
-interface Gym {
-  id: string;
-  name: string;
-  address: string;
-  city: string;
-  state: string;
-  zipCode: string;
-  contactEmail: string;
-  contactPhone?: string;
-  website?: string;
-  isApproved: boolean;
-  adminId?: string;
-  createdAt: string;
-  memberCount: number;
-  activeEvents: number;
-}
+import { useGyms, Gym } from '../../hooks/useSupabaseData';
+import { useAuth } from '../../contexts/AuthContext';
+import { isSupabaseConfigured, createGym as createGymApi, updateGym as updateGymApi, deleteGym as deleteGymApi } from '../../lib/supabase';
+import type { Database } from '../../types/database';
 
 export const GymManagement: React.FC = () => {
-  const [gyms, setGyms] = useState<Gym[]>([
-    {
-      id: 'gym-1',
-      name: 'Elite Gymnastics Center',
-      address: '123 Main Street',
-      city: 'New York',
-      state: 'NY',
-      zipCode: '10001',
-      contactEmail: 'info@elitegymnastics.com',
-      contactPhone: '(555) 123-4567',
-      website: 'www.elitegymnastics.com',
-      isApproved: true,
-      adminId: 'admin-1',
-      createdAt: '2024-01-15',
-      memberCount: 45,
-      activeEvents: 3
-    },
-    {
-      id: 'gym-2',
-      name: 'Metro Sports Complex',
-      address: '456 Oak Avenue',
-      city: 'Chicago',
-      state: 'IL',
-      zipCode: '60601',
-      contactEmail: 'contact@metrosports.com',
-      contactPhone: '(555) 987-6543',
-      website: 'www.metrosports.com',
-      isApproved: true,
-      adminId: 'admin-2',
-      createdAt: '2024-02-01',
-      memberCount: 38,
-      activeEvents: 2
-    },
-    {
-      id: 'gym-3',
-      name: 'Sunshine Gymnastics Academy',
-      address: '789 Pine Road',
-      city: 'Miami',
-      state: 'FL',
-      zipCode: '33101',
-      contactEmail: 'hello@sunshinegym.com',
-      contactPhone: '(555) 456-7890',
-      isApproved: false,
-      createdAt: '2024-03-10',
-      memberCount: 0,
-      activeEvents: 0
-    },
-    {
-      id: 'gym-4',
-      name: 'Pacific Coast Gymnastics',
-      address: '321 Beach Boulevard',
-      city: 'Los Angeles',
-      state: 'CA',
-      zipCode: '90210',
-      contactEmail: 'info@pacificcoast.com',
-      contactPhone: '(555) 321-0987',
-      website: 'www.pacificcoast.com',
-      isApproved: true,
-      adminId: 'admin-4',
-      createdAt: '2024-01-20',
-      memberCount: 52,
-      activeEvents: 4
-    }
-  ]);
+  const { user } = useAuth();
+  const { gyms, loading, error, refetch, addGym, updateGym: updateGymLocal, removeGym } = useGyms();
 
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [editingGym, setEditingGym] = useState<Gym | null>(null);
@@ -100,31 +25,63 @@ export const GymManagement: React.FC = () => {
     website: ''
   });
 
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg">
+        Error loading gyms: {error}
+      </div>
+    );
+  }
+
   const filteredGyms = gyms.filter(gym => {
     const matchesSearch = gym.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
                          gym.city.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         gym.contactEmail.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesFilter = filterStatus === 'all' || 
-                         (filterStatus === 'approved' && gym.isApproved) ||
-                         (filterStatus === 'pending' && !gym.isApproved);
+                         gym.contact_email.toLowerCase().includes(searchTerm.toLowerCase());
+    const matchesFilter = filterStatus === 'all' ||
+                         (filterStatus === 'approved' && gym.is_approved) ||
+                         (filterStatus === 'pending' && !gym.is_approved);
     return matchesSearch && matchesFilter;
   });
 
-  const approveGym = (gymId: string) => {
-    setGyms(prev => prev.map(gym => 
-      gym.id === gymId ? { ...gym, isApproved: true } : gym
-    ));
-  };
-
-  const rejectGym = (gymId: string) => {
-    if (confirm('Are you sure you want to reject this gym application?')) {
-      setGyms(prev => prev.filter(gym => gym.id !== gymId));
+  const approveGym = async (gymId: string) => {
+    if (isSupabaseConfigured && !user?.id?.startsWith('demo-')) {
+      await updateGymApi(gymId, { is_approved: true });
+      await refetch();
+    } else {
+      const g = gyms.find((gm) => gm.id === gymId);
+      if (g) {
+        updateGymLocal({ ...g, is_approved: true });
+      }
     }
   };
 
-  const deleteGym = (gymId: string) => {
+  const rejectGym = async (gymId: string) => {
+    if (confirm('Are you sure you want to reject this gym application?')) {
+      if (isSupabaseConfigured && !user?.id?.startsWith('demo-')) {
+        await deleteGymApi(gymId);
+        await refetch();
+      } else {
+        removeGym(gymId);
+      }
+    }
+  };
+
+  const handleDeleteGym = async (gymId: string) => {
     if (confirm('Are you sure you want to delete this gym? This action cannot be undone.')) {
-      setGyms(prev => prev.filter(gym => gym.id !== gymId));
+      if (isSupabaseConfigured && !user?.id?.startsWith('demo-')) {
+        await deleteGymApi(gymId);
+        await refetch();
+      } else {
+        removeGym(gymId);
+      }
     }
   };
 
@@ -132,24 +89,49 @@ export const GymManagement: React.FC = () => {
     e.preventDefault();
     
     if (editingGym) {
-      // Update existing gym
-      setGyms(prev => prev.map(gym => 
-        gym.id === editingGym.id 
-          ? { ...gym, ...formData }
-          : gym
-      ));
+      const updates = {
+        name: formData.name,
+        address: formData.address,
+        city: formData.city,
+        state: formData.state,
+        zip_code: formData.zipCode,
+        contact_email: formData.contactEmail,
+        contact_phone: formData.contactPhone || null,
+        website: formData.website || null,
+        updated_at: new Date().toISOString(),
+      };
+      if (isSupabaseConfigured && !user?.id?.startsWith('demo-')) {
+        await updateGymApi(editingGym.id, updates);
+        await refetch();
+      } else {
+        updateGymLocal({ ...editingGym, ...updates } as Gym);
+      }
       setEditingGym(null);
     } else {
       // Create new gym
-      const newGym: Gym = {
-        id: `gym-${Date.now()}`,
-        ...formData,
-        isApproved: false,
-        createdAt: new Date().toISOString().split('T')[0],
-        memberCount: 0,
-        activeEvents: 0
+      const newGym: Database['public']['Tables']['gyms']['Insert'] = {
+        name: formData.name,
+        address: formData.address,
+        city: formData.city,
+        state: formData.state,
+        zip_code: formData.zipCode,
+        contact_email: formData.contactEmail,
+        contact_phone: formData.contactPhone || null,
+        website: formData.website || null,
+        is_approved: false,
+        admin_id: user?.id || null,
       };
-      setGyms(prev => [...prev, newGym]);
+      if (isSupabaseConfigured && !user?.id?.startsWith('demo-')) {
+        await createGymApi(newGym);
+        await refetch();
+      } else {
+        addGym({
+          ...(newGym as Gym),
+          id: `demo-${Date.now()}`,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        } as Gym);
+      }
     }
     
     setFormData({
@@ -172,9 +154,9 @@ export const GymManagement: React.FC = () => {
       address: gym.address,
       city: gym.city,
       state: gym.state,
-      zipCode: gym.zipCode,
-      contactEmail: gym.contactEmail,
-      contactPhone: gym.contactPhone || '',
+      zipCode: gym.zip_code,
+      contactEmail: gym.contact_email,
+      contactPhone: gym.contact_phone || '',
       website: gym.website || ''
     });
     setShowCreateForm(true);
@@ -197,9 +179,9 @@ export const GymManagement: React.FC = () => {
 
   const stats = {
     total: gyms.length,
-    approved: gyms.filter(g => g.isApproved).length,
-    pending: gyms.filter(g => !g.isApproved).length,
-    totalMembers: gyms.reduce((sum, g) => sum + g.memberCount, 0)
+    approved: gyms.filter(g => g.is_approved).length,
+    pending: gyms.filter(g => !g.is_approved).length,
+    totalMembers: gyms.length
   };
 
   return (
@@ -293,7 +275,7 @@ export const GymManagement: React.FC = () => {
               <div className="flex items-center justify-between mb-4">
                 <h3 className="text-xl font-bold text-gray-900">{gym.name}</h3>
                 <div className="flex items-center space-x-2">
-                  {gym.isApproved ? (
+                  {gym.is_approved ? (
                     <span className="px-3 py-1 bg-green-100 text-green-800 text-sm font-medium rounded-full flex items-center space-x-1">
                       <CheckCircle className="w-4 h-4" />
                       <span>Approved</span>
@@ -310,16 +292,16 @@ export const GymManagement: React.FC = () => {
               <div className="space-y-3 mb-6">
                 <div className="flex items-center space-x-2 text-gray-600">
                   <MapPin className="w-4 h-4" />
-                  <span>{gym.address}, {gym.city}, {gym.state} {gym.zipCode}</span>
+                  <span>{gym.address}, {gym.city}, {gym.state} {gym.zip_code}</span>
                 </div>
                 <div className="flex items-center space-x-2 text-gray-600">
                   <Mail className="w-4 h-4" />
-                  <span>{gym.contactEmail}</span>
+                  <span>{gym.contact_email}</span>
                 </div>
-                {gym.contactPhone && (
+                {gym.contact_phone && (
                   <div className="flex items-center space-x-2 text-gray-600">
                     <Phone className="w-4 h-4" />
-                    <span>{gym.contactPhone}</span>
+                    <span>{gym.contact_phone}</span>
                   </div>
                 )}
                 {gym.website && (
@@ -330,14 +312,14 @@ export const GymManagement: React.FC = () => {
                 )}
               </div>
 
-              {gym.isApproved && (
+              {gym.is_approved && (
                 <div className="grid grid-cols-2 gap-4 mb-6 p-4 bg-gray-50 rounded-lg">
                   <div className="text-center">
-                    <div className="text-2xl font-bold text-blue-600">{gym.memberCount}</div>
+                    <div className="text-2xl font-bold text-blue-600">0</div>
                     <div className="text-sm text-gray-600">Members</div>
                   </div>
                   <div className="text-center">
-                    <div className="text-2xl font-bold text-purple-600">{gym.activeEvents}</div>
+                    <div className="text-2xl font-bold text-purple-600">0</div>
                     <div className="text-sm text-gray-600">Active Events</div>
                   </div>
                 </div>
@@ -345,10 +327,10 @@ export const GymManagement: React.FC = () => {
 
               <div className="flex items-center justify-between pt-4 border-t border-gray-200">
                 <div className="text-sm text-gray-500">
-                  Added: {new Date(gym.createdAt).toLocaleDateString()}
+                  Added: {new Date(gym.created_at).toLocaleDateString()}
                 </div>
                 <div className="flex space-x-2">
-                  {!gym.isApproved && (
+                  {!gym.is_approved && (
                     <>
                       <button
                         onClick={() => approveGym(gym.id)}
@@ -371,7 +353,7 @@ export const GymManagement: React.FC = () => {
                     <Edit className="w-4 h-4" />
                   </button>
                   <button
-                    onClick={() => deleteGym(gym.id)}
+                    onClick={() => handleDeleteGym(gym.id)}
                     className="p-2 text-gray-400 hover:text-red-600 transition-colors"
                   >
                     <Trash2 className="w-4 h-4" />

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -43,48 +43,6 @@ export const useAuth = () => {
   return context;
 };
 
-// Demo user profiles
-const demoUsers: { [key: string]: UserProfile } = {
-  'admin@demo.com': {
-    id: 'demo-admin-id',
-    email: 'admin@demo.com',
-    first_name: 'League',
-    last_name: 'Administrator',
-    role: 'admin',
-    gym_id: null,
-    phone: null,
-    date_of_birth: null,
-    is_active: true,
-    created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString()
-  },
-  'coach@demo.com': {
-    id: 'demo-coach-id',
-    email: 'coach@demo.com',
-    first_name: 'Sarah',
-    last_name: 'Johnson',
-    role: 'coach',
-    gym_id: 'demo-gym-id',
-    phone: null,
-    date_of_birth: null,
-    is_active: true,
-    created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString()
-  },
-  'gymnast@demo.com': {
-    id: 'demo-gymnast-id',
-    email: 'gymnast@demo.com',
-    first_name: 'Emma',
-    last_name: 'Davis',
-    role: 'gymnast',
-    gym_id: 'demo-gym-id',
-    phone: null,
-    date_of_birth: null,
-    is_active: true,
-    created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString()
-  }
-};
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<UserProfile | null>(null);
@@ -230,7 +188,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           console.error('[auth] Exception creating user profile:', createErr);
         }
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('[auth] Error loading user profile:', err);
       console.log('[auth] No user profile found, continuing without profile data');
     } finally {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -304,6 +304,22 @@ export const getGymnastsByGym = async (gymId: string) => {
   return { data, error };
 };
 
+export const getGyms = async () => {
+  devLog('[supabase] getGyms');
+  const { data, error } = await supabase
+    .from('gyms')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    devError('[supabase] getGyms error:', error);
+  } else {
+    devLog('[supabase] getGyms result count:', data?.length);
+  }
+
+  return { data, error };
+};
+
 export const getNotifications = async (userId: string) => {
   devLog('[supabase] getNotifications userId:', userId);
   const { data, error } = await supabase
@@ -368,6 +384,69 @@ export const updateEvent = async (
     devError('[supabase] updateEvent error:', error);
   } else {
     devLog('[supabase] updateEvent updated id:', data?.id);
+  }
+  return { data, error };
+};
+
+export const createGym = async (
+  gym: Database['public']['Tables']['gyms']['Insert']
+) => {
+  devLog('[supabase] createGym', gym);
+  const { data, error } = await supabase
+    .from('gyms')
+    .insert(gym)
+    .single();
+  if (error) {
+    devError('[supabase] createGym error:', error);
+  } else {
+    devLog('[supabase] createGym id:', data?.id);
+  }
+  return { data, error };
+};
+
+export const updateGym = async (
+  id: string,
+  updates: Database['public']['Tables']['gyms']['Update']
+) => {
+  devLog('[supabase] updateGym id:', id, 'updates:', updates);
+  const { data, error } = await supabase
+    .from('gyms')
+    .update(updates)
+    .eq('id', id)
+    .single();
+  if (error) {
+    devError('[supabase] updateGym error:', error);
+  } else {
+    devLog('[supabase] updateGym updated id:', data?.id);
+  }
+  return { data, error };
+};
+
+export const deleteGym = async (id: string) => {
+  devLog('[supabase] deleteGym id:', id);
+  const { error } = await supabase.from('gyms').delete().eq('id', id);
+  if (error) {
+    devError('[supabase] deleteGym error:', error);
+  } else {
+    devLog('[supabase] deleteGym success');
+  }
+  return { error };
+};
+
+export const updateGymnast = async (
+  id: string,
+  updates: Database['public']['Tables']['gymnasts']['Update']
+) => {
+  devLog('[supabase] updateGymnast id:', id, 'updates:', updates);
+  const { data, error } = await supabase
+    .from('gymnasts')
+    .update(updates)
+    .eq('id', id)
+    .single();
+  if (error) {
+    devError('[supabase] updateGymnast error:', error);
+  } else {
+    devLog('[supabase] updateGymnast updated id:', data?.id);
   }
   return { data, error };
 };


### PR DESCRIPTION
## Summary
- add CRUD helpers for gyms and gymnasts in supabase client
- implement `useGyms` hook with Supabase sync
- fetch gyms via `useGyms` in GymManagement and persist to Supabase
- use `useGymnasts` hook in GymnastManagement and update Supabase on approve
- cleanup unused demo users and fix ESLint warnings

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a46f76a348325a273053260c4cc42