### PR TITLE
Enable adding and deleting members

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -415,6 +415,51 @@ export const createGym = async (
   return { data, error };
 };
 
+export const createMember = async (
+  member: Database['public']['Tables']['user_profiles']['Insert']
+) => {
+  devLog('[supabase] createMember', member);
+  const { data, error } = await supabase
+    .from('user_profiles')
+    .insert(member)
+    .single();
+  if (error) {
+    devError('[supabase] createMember error:', error);
+  } else {
+    devLog('[supabase] createMember id:', data?.id);
+  }
+  return { data, error };
+};
+
+export const updateMember = async (
+  id: string,
+  updates: Database['public']['Tables']['user_profiles']['Update']
+) => {
+  devLog('[supabase] updateMember id:', id, 'updates:', updates);
+  const { data, error } = await supabase
+    .from('user_profiles')
+    .update(updates)
+    .eq('id', id)
+    .single();
+  if (error) {
+    devError('[supabase] updateMember error:', error);
+  } else {
+    devLog('[supabase] updateMember updated id:', data?.id);
+  }
+  return { data, error };
+};
+
+export const deleteMember = async (id: string) => {
+  devLog('[supabase] deleteMember id:', id);
+  const { error } = await supabase.from('user_profiles').delete().eq('id', id);
+  if (error) {
+    devError('[supabase] deleteMember error:', error);
+  } else {
+    devLog('[supabase] deleteMember success');
+  }
+  return { error };
+};
+
 export const updateGym = async (
   id: string,
   updates: Database['public']['Tables']['gyms']['Update']


### PR DESCRIPTION
## Summary
- add Supabase helpers for member CRUD
- create `useMembers` hook for fetching and managing members
- connect MemberManagement component to Supabase

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688a5b0540d48325812d256d719b27c9