### PR TITLE
Enable verbose logging via env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ VITE_SUPABASE_URL=your_supabase_project_url
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 SUPABASE_DB_URL=your_supabase_connection_string
 
+# Enable verbose logging in any environment
+VITE_VERBOSE_LOGGING=false
+
 # Example:
 # VITE_SUPABASE_URL=https://your-project.supabase.co
 # VITE_SUPABASE_ANON_KEY=your-anon-key-here

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ initializes without errors.
 Every request to Supabase is logged in development mode, showing the HTTP
 method, URL, response status, and how long the request took. Errors are printed
 to the console to help diagnose network or permission issues.
+Set `VITE_VERBOSE_LOGGING=true` in your `.env` to enable these logs outside of development.
 
 ## 🗄️ Database Schema
 
@@ -186,6 +187,7 @@ npm run build
 Production environment needs:
 - `VITE_SUPABASE_URL`
 - `VITE_SUPABASE_ANON_KEY`
+- `VITE_VERBOSE_LOGGING` (set to `true` for detailed logs)
 - Stripe keys (configured in Supabase Edge Functions)
 
 ## 📊 Analytics & Reporting

--- a/src/components/Auth/LoginForm.tsx
+++ b/src/components/Auth/LoginForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Trophy, Mail, Lock, Eye, EyeOff } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
+import { log, error as logError } from '../../lib/logger';
 
 interface LoginFormProps {
   onShowSignup: () => void;
@@ -15,13 +16,13 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onShowSignup }) => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
-    console.log('Form submitted with:', email, password);
+    log('Form submitted with:', email, password);
     
     try {
       await login(email, password);
-      console.log('Login successful!');
+      log('Login successful!');
     } catch (err) {
-      console.error('Login error in form:', err);
+      logError('Login error in form:', err);
       setError(err instanceof Error ? err.message : 'Invalid email or password');
     }
   };

--- a/src/components/Dashboard/AdminDashboard.tsx
+++ b/src/components/Dashboard/AdminDashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Users, Calendar, Trophy, TrendingUp, CheckCircle, Clock, AlertCircle } from 'lucide-react';
 import { useEvents, useNotifications } from '../../hooks/useSupabaseData';
+import { log } from '../../lib/logger';
 
 interface AdminDashboardProps {
   onCreateEvent?: () => void;
@@ -45,12 +46,12 @@ export const AdminDashboard: React.FC<AdminDashboardProps> = ({
   };
 
   const handleSendAnnouncement = () => {
-    console.log('Opening announcement modal');
+    log('Opening announcement modal');
     setShowAnnouncementModal(true);
   };
 
   const handleExportData = () => {
-    console.log('Opening export modal');
+    log('Opening export modal');
     setShowExportModal(true);
   };
 

--- a/src/components/Dashboard/CoachDashboard.tsx
+++ b/src/components/Dashboard/CoachDashboard.tsx
@@ -53,13 +53,14 @@ export const CoachDashboard: React.FC = () => {
   };
 
   const handleSubmitGymnast = () => {
+    log('Submitting new gymnast data:', gymnastData);
     // Validate required fields
     if (!gymnastData.firstName || !gymnastData.lastName || !gymnastData.email || 
         !gymnastData.level || !gymnastData.dateOfBirth || !gymnastData.teamName) {
       alert('Please fill in all required fields: First Name, Last Name, Email, Date of Birth, Level, and Team.');
       return;
     }
-
+    
     const newGymnast = {
       id: `gymnast-${Date.now()}`,
       user_id: `user-${Date.now()}`,
@@ -81,7 +82,7 @@ export const CoachDashboard: React.FC = () => {
         date_of_birth: gymnastData.dateOfBirth
       }
     };
-    
+    log('New gymnast object created:', newGymnast, 'calling addGymnast');
     addGymnast(newGymnast);
     alert(`Gymnast ${gymnastData.firstName} ${gymnastData.lastName} added successfully!`);
     setShowAddGymnastModal(false);

--- a/src/components/Dashboard/CoachDashboard.tsx
+++ b/src/components/Dashboard/CoachDashboard.tsx
@@ -4,6 +4,7 @@ import { Users, Calendar, CheckCircle, Clock, Trophy, Star } from 'lucide-react'
 import { useNotifications } from '../../hooks/useSupabaseData';
 import { useGymnastContext } from '../../contexts/GymnastContext';
 import { useAuth } from '../../contexts/AuthContext';
+import { log } from '../../lib/logger';
 
 export const CoachDashboard: React.FC = () => {
   const { user } = useAuth();
@@ -155,13 +156,13 @@ export const CoachDashboard: React.FC = () => {
       approved_by_coach_id: user?.id,
       membership_status: 'active'
     });
-    console.log('Gymnast approved, updated state');
+    log('Gymnast approved, updated state');
   };
 
   const rejectGymnast = (gymnastId: string) => {
     if (confirm('Are you sure you want to reject this gymnast application?')) {
       removeGymnast(gymnastId);
-      console.log('Gymnast rejected and removed');
+      log('Gymnast rejected and removed');
     }
   };
 

--- a/src/components/Gymnasts/GymnastManagement.tsx
+++ b/src/components/Gymnasts/GymnastManagement.tsx
@@ -3,6 +3,7 @@ import { Users, Search, Filter, CheckCircle, Clock, Plus, Mail } from 'lucide-re
 import { useGymnasts } from '../../hooks/useSupabaseData';
 import { updateGymnast, isSupabaseConfigured } from '../../lib/supabase';
 import { useAuth } from '../../contexts/AuthContext';
+import { log, error as logError } from '../../lib/logger';
 
 export const GymnastManagement: React.FC = () => {
   const { user } = useAuth();
@@ -54,10 +55,10 @@ export const GymnastManagement: React.FC = () => {
         });
         await refetch();
       } else {
-        console.log('Gymnast approved in demo mode');
+        log('Gymnast approved in demo mode');
       }
     } catch (err) {
-      console.error('Failed to approve gymnast:', err);
+      logError('Failed to approve gymnast:', err);
     }
   };
 

--- a/src/components/Members/MemberManagement.tsx
+++ b/src/components/Members/MemberManagement.tsx
@@ -8,6 +8,7 @@ import {
   updateMember as updateMemberApi,
   deleteMember as deleteMemberApi
 } from '../../lib/supabase';
+import { log } from '../../lib/logger';
 
 interface Member {
   id: string;
@@ -110,6 +111,7 @@ export const MemberManagement: React.FC = () => {
   };
 
   const deleteMember = async (memberId: string) => {
+    log('[memberManagemnet] deleteMember called for ID:', memberId);
     if (confirm('Are you sure you want to delete this member? This action cannot be undone.')) {
       if (isSupabaseConfigured && !user?.id?.startsWith('demo-')) {
         await deleteMemberApi(memberId);
@@ -121,6 +123,7 @@ export const MemberManagement: React.FC = () => {
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
+    log('[memberManagement] handleSubmit called with formData:', formData);
     e.preventDefault();
 
     if (editingMember) {
@@ -139,6 +142,7 @@ export const MemberManagement: React.FC = () => {
         await updateMemberApi(editingMember.id, updates);
         await refetch();
       } else {
+        log('[memberManagement] supaBase not configured, updating member locally');
         updateMemberLocal({ ...editingMember, ...formData, isActive: editingMember.isActive });
       }
       setEditingMember(null);

--- a/src/contexts/GymnastContext.tsx
+++ b/src/contexts/GymnastContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { useAuth } from './AuthContext';
+import { log, error as logError } from '../lib/logger';
 
 interface Gymnast {
   id: string;
@@ -53,7 +54,7 @@ export const GymnastProvider: React.FC<{ children: React.ReactNode }> = ({ child
       try {
         setGymnasts(JSON.parse(storedGymnasts));
       } catch (error) {
-        console.error('Error parsing stored gymnasts:', error);
+        logError('Error parsing stored gymnasts:', error);
       }
     } else {
       // Initialize with demo data
@@ -109,7 +110,7 @@ export const GymnastProvider: React.FC<{ children: React.ReactNode }> = ({ child
   useEffect(() => {
     if (gymnasts.length >= 0) {
       localStorage.setItem('gymnasts', JSON.stringify(gymnasts));
-      console.log('Saved gymnasts to localStorage:', gymnasts.length);
+      log('Saved gymnasts to localStorage:', gymnasts.length);
     }
   }, [gymnasts]);
 
@@ -121,19 +122,19 @@ export const GymnastProvider: React.FC<{ children: React.ReactNode }> = ({ child
 
   const addGymnast = (gymnast: Gymnast) => {
     setGymnasts(prev => [...prev, gymnast]);
-    console.log('Added gymnast:', gymnast.user?.first_name);
+    log('Added gymnast:', gymnast.user?.first_name);
   };
 
   const updateGymnast = (id: string, updates: Partial<Gymnast>) => {
     setGymnasts(prev => prev.map(g => 
       g.id === id ? { ...g, ...updates, updated_at: new Date().toISOString() } : g
     ));
-    console.log('Updated gymnast:', id, updates);
+    log('Updated gymnast:', id, updates);
   };
 
   const removeGymnast = (id: string) => {
     setGymnasts(prev => prev.filter(g => g.id !== id));
-    console.log('Removed gymnast:', id);
+    log('Removed gymnast:', id);
   };
 
   return (

--- a/src/hooks/useSupabaseData.ts
+++ b/src/hooks/useSupabaseData.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { supabase, isSupabaseConfigured } from '../lib/supabase';
 import { useAuth } from '../contexts/AuthContext';
 import type { Database } from '../types/database';
+import { error as logError } from '../lib/logger';
 
 export type EventWithRelations = Database['public']['Tables']['events']['Row'] & {
   host_gym: Database['public']['Tables']['gyms']['Row'];
@@ -672,7 +673,7 @@ export const useNotifications = () => {
         )
       );
     } catch (err) {
-      console.error('Failed to mark notification as read:', err);
+      logError('Failed to mark notification as read:', err);
     }
   };
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,13 @@
+const verbose = import.meta.env.DEV || import.meta.env.VITE_VERBOSE_LOGGING === 'true';
+
+export const log = (...args: unknown[]) => {
+  if (verbose) console.log(...args);
+};
+
+export const warn = (...args: unknown[]) => {
+  if (verbose) console.warn(...args);
+};
+
+export const error = (...args: unknown[]) => {
+  if (verbose) console.error(...args);
+};

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,13 +1,6 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { Database } from '../types/database';
-
-const devLog = (...args: unknown[]) => {
-  if (import.meta.env.DEV) console.log(...args);
-};
-
-const devError = (...args: unknown[]) => {
-  if (import.meta.env.DEV) console.error(...args);
-};
+import { log as devLog, error as devError } from './logger';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;


### PR DESCRIPTION
## Summary
- add `VITE_VERBOSE_LOGGING` option in `.env.example`
- provide instructions in README for enabling detailed logs
- centralize logging in new `logger.ts`
- use logger across contexts and components
- allow supabase client to respect verbose logging

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a86a9f138832580044ee58929e72b